### PR TITLE
Ignore it if we get a clearly invalid snitch_id.

### DIFF
--- a/dead_mans_snitch.gemspec
+++ b/dead_mans_snitch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{dead_mans_snitch}
-  s.version = "1.1.0"
+  s.version = "1.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Kyle Burton <kyle.burton@gmail.com>"]

--- a/lib/dead_mans_snitch.rb
+++ b/lib/dead_mans_snitch.rb
@@ -5,6 +5,7 @@ require 'uri'
 
 class DeadMansSnitch
   def self.report snitch_id, message=nil
+    return false if snitch_id.nil? || snitch_id == ''
     begin
       dead_mans_snitch_url = "https://nosnch.in/#{snitch_id}"
       uri                  = URI.parse(dead_mans_snitch_url)

--- a/spec/lib/dead_mans_snitch_spec.rb
+++ b/spec/lib/dead_mans_snitch_spec.rb
@@ -7,33 +7,47 @@ describe DeadMansSnitch do
   describe '.report' do
     subject { described_class.report snitch_id }
 
-    context 'when remote accepts the message' do
-      before do
-        stub_request(:post, "https://nosnch.in/#{snitch_id}").
-        to_return(:status => 202, :body => "Got it, thanks!")
+    context 'when passed a snitch_id' do
+      context 'when remote accepts the message' do
+        before do
+          stub_request(:post, "https://nosnch.in/#{snitch_id}").
+          to_return(:status => 202, :body => "Got it, thanks!")
+        end
+
+        it 'returns http response' do
+          expect(subject.code).to eq('202')
+        end
       end
 
-      it 'returns http response' do
-        expect(subject.code).to eq('202')
+      context 'when remote returns an error' do
+        before do
+          stub_request(:post, "https://nosnch.in/#{snitch_id}").
+          to_return(:status => 400, :body => "Bad Snitch")
+        end
+
+        it 'returns http response' do
+          expect(subject.code).to eq('400')
+        end
+      end
+
+      context 'when Net::HTTP throws an error' do
+        it 'swallows the error' do
+          expect_any_instance_of(Net::HTTP).to receive(:request).and_raise(Timeout::Error)
+          expect { subject }.to_not raise_error
+        end
+
+        it { is_expected.to be_falsey }
       end
     end
 
-    context 'when remote returns an error' do
-      before do
-        stub_request(:post, "https://nosnch.in/#{snitch_id}").
-        to_return(:status => 400, :body => "Bad Snitch")
-      end
+    context 'when passed nil as snitch_id' do
+      let(:snitch_id) { nil }
 
-      it 'returns http response' do
-        expect(subject.code).to eq('400')
-      end
+      it { is_expected.to be_falsey }
     end
 
-    context 'when Net::HTTP throws an error' do
-      it 'swallows the error' do
-        expect_any_instance_of(Net::HTTP).to receive(:request).and_raise(Timeout::Error)
-        expect { subject }.to_not raise_error
-      end
+    context 'when passed empty string as snitch_id' do
+      let(:snitch_id) { '' }
 
       it { is_expected.to be_falsey }
     end


### PR DESCRIPTION
This will make it easy to disable reporting to dms by omitting snitch
ids on staging system. One can write code like the following.

```
DeadMansSnitch.report(ENV['SNITCH_ID'])
```

With that one can set a snitch id on production and omit setting a
snitch id on staging to ensure we don't send requests from staging to
dms.
