### PR TITLE
Update gemspec to support ruby2.6

### DIFF
--- a/dead_mans_snitch.gemspec
+++ b/dead_mans_snitch.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.email = ["kburton@gmail.com"]
   s.extra_rdoc_files = ["README.textile"]
   s.files = ["README.textile", "lib/dead_mans_snitch.rb"]
-  s.has_rdoc = false
   s.homepage = %q{https://github.com/kyleburton/dead-mans-snitch}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.1}


### PR DESCRIPTION
Fix the deprecation warning
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /bundle/bundler/gems/dead-mans-snitch-3dfca0b50318/dead_mans_snitch.gemspec:12.
```